### PR TITLE
Allow ScreenSharing in Frames

### DIFF
--- a/background-script.js
+++ b/background-script.js
@@ -2,6 +2,11 @@
 function onMessageExternal(request, sender, sendResponse) {
     if (request && request.message) {
         if (request.message === 'chooseDesktopMedia') {
+
+            // Make sure that the tab url matches the url of the frame requesting the media. This
+            // is necessary to run screensharing inside of an iframe, such as on Codepen.
+            sender.tab.url = sender.url;
+
             chrome.desktopCapture.chooseDesktopMedia(['screen', 'window'], sender.tab, function (mediaSourceId) {
                 if (!mediaSourceId || !mediaSourceId.length) {
                     sendResponse({

--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,4 @@
-{    
+{
     "name": "Kandy.io Chrome Extension",
     "description": "Kandy.io sample extension to enable screensharing",
     "version": "1.0.0",
@@ -22,6 +22,6 @@
         "16": "icon_16.png",
         "32": "icon_32.png",
         "48": "icon_48.png",
-        "128": "icon_128.png",
+        "128": "icon_128.png"
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Kandy.io Chrome Extension",
     "description": "Kandy.io sample extension to enable screensharing",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Kandy.io",
     "homepage_url": "http://kandy.io/",
 


### PR DESCRIPTION
The extension was not working in frames because it would not use the proper URL (for the frame) when capturing the media stream. This PR updates the extension to work in frames by ensuring the proper URL is used for frames. The method used is the intended way to resolve this scenario. This change does not affect usage outside of frames.

Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=425344#c2